### PR TITLE
Add snooze option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A responsive task reminder web application built with HTML, jQuery, and Tailwind
 - 💾 **Persistent Storage**: Tasks are saved locally and persist between sessions
 - ⏱️ **Real-time Updates**: Live countdown timers for all active tasks
 - 🎨 **Modern UI**: Clean, modern design using Tailwind CSS
+- 😴 **Snooze Reminders**: Use the "Snooze" button in a reminder notification to delay the task by five minutes
 
 ## Technology Stack
 
@@ -48,6 +49,7 @@ A responsive task reminder web application built with HTML, jQuery, and Tailwind
 - **Browser Notifications**: Native OS notifications (requires permission)
 - **Audio Notifications**: Pleasant two-tone chime using Web Audio API
 - **Fallback Support**: Graceful degradation for unsupported browsers
+- **Snooze Option**: Click "Snooze" in a reminder notification to postpone that task for another five minutes
 
 ### Responsive Design
 - Mobile-first approach with Tailwind CSS

--- a/task-reminder.html
+++ b/task-reminder.html
@@ -118,6 +118,9 @@
     <div id="notificationContainer" class="fixed top-4 right-4 z-50 space-y-2"></div>
 
     <script>
+        // Default number of minutes to postpone a task when snoozed
+        const DEFAULT_SNOOZE_MINUTES = 5;
+
         class TaskReminder {
             constructor() {
                 this.tasks = [];
@@ -251,8 +254,13 @@
                 // Enhanced desktop notification
                 this.showDesktopNotification(task);
                 
-                // Visual notification
-                this.showNotification(`Reminder: ${task.description}`, 'reminder', 10000);
+                // Visual notification with snooze option
+                this.showNotification(
+                    `Reminder: ${task.description}`,
+                    'reminder',
+                    10000,
+                    { snoozeCallback: () => this.snoozeTask(task.id, DEFAULT_SNOOZE_MINUTES) }
+                );
                 
                 // Mark task as completed
                 task.completed = true;
@@ -523,30 +531,44 @@
                 }
             }
 
-            showNotification(message, type = 'info', duration = 5000) {
+            showNotification(message, type = 'info', duration = 5000, options = {}) {
                 const colors = {
                     success: 'bg-green-500',
                     error: 'bg-red-500',
                     info: 'bg-blue-500',
                     reminder: 'bg-purple-500'
                 };
-                
+
+                const snoozeBtn = options.snoozeCallback ?
+                    `<button type="button" class="snooze-btn ml-2 px-2 py-1 bg-white bg-opacity-20 rounded hover:bg-opacity-30 text-sm">Snooze ${DEFAULT_SNOOZE_MINUTES}m</button>` : '';
+
                 const notification = $(`
                     <div class="notification ${colors[type]} text-white px-6 py-4 rounded-lg shadow-lg max-w-sm">
                         <div class="flex items-center justify-between">
                             <span>${message}</span>
-                            <button class="ml-4 text-white hover:text-gray-200 focus:outline-none">
-                                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                                </svg>
-                            </button>
+                            <div class="flex items-center">
+                                ${snoozeBtn}
+                                <button type="button" aria-label="Dismiss notification" class="ml-4 text-white hover:text-gray-200 focus:outline-none">
+                                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                                    </svg>
+                                </button>
+                            </div>
                         </div>
                     </div>
                 `);
-                
-                notification.find('button').on('click', function() {
+
+                // Close button is always the last button
+                notification.find('button').last().on('click', function() {
                     notification.remove();
                 });
+
+                if (options.snoozeCallback) {
+                    notification.find('.snooze-btn').on('click', () => {
+                        notification.remove();
+                        options.snoozeCallback();
+                    });
+                }
                 
                 $('#notificationContainer').append(notification);
                 


### PR DESCRIPTION
## Summary
- add a snooze button for reminder notifications
- hook up snooze functionality in `triggerReminder`
- document snooze option in README
- refine snooze feature with configurable default time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e7000c894832bb718979ee984807a